### PR TITLE
Readme changes in line with devops-docker-images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # XS Command-Line Client Dockerfile
 ## Description
-This Dockerfile wraps the XS command-line client that can be used to perform various developer- and administrator-related tasks. In the context of [project "Piper"][piper] it is used to deploy an SAP HANA XS Advanced application to an SAP HANA Server.
+To bring an SAP HANA XS Advanced application to an SAP HANA Server, deploy the application with the XS command-line tool. 
+With this Dockerfile, you can wrap the XS command-line client and run the resulting image with the Jenkins pipeline library of [project "Piper"][piper]. 
 
 ## Requirements
-
-A [Docker](https://www.docker.com/) environment is required to build and run Docker images. You should be familiar with basic Docker commands to build and run the image. To fetch the Dockerfiles and this project's sources to build them locally, a [Git client](https://git-scm.com/) is required.
-
+* General requirements can be found in the [repository readme][general]
 * An S-User for [SAP ONE][sapone]
 * Download XS command-line client ```XS_CLIENT00P_<version>.ZIP``` for Linux on x86_64 from [SAP ONE][sapone]
 
 ## How to Build It
 
-This image is not available at hub.docker.com. Instead, you need to [build][dockerbuild] this Dockerfile before using it. Here, you can find a [tutorial][xsclient] on how to get the XS command-line client package.
+This image is not provided on hub.docker.com. Instead, [build][dockerbuild] this Dockerfile locally before using it. Either clone the repository or download the Dockerfile and put the XS CLI ZIP file into the same directory. Here, you can find a [tutorial][xsclient] on how to get the XS command-line client package.
 
 ### Build Arguments
 | Argument | Description |
@@ -20,7 +19,7 @@ This image is not available at hub.docker.com. Instead, you need to [build][dock
 
 Example:
 ```
-docker build -t ppiper/xs-cli --build-arg XSZIP=XS_CLIENT00P_<version>.ZIP --file Dockerfile https://github.com/SAP/devops-docker-images.git#:xs-cli
+docker build -t ppiper/xs-cli --build-arg XSZIP=XS_CLIENT00P_<version>.ZIP .
 ```
 
 ## How to Execute It
@@ -30,8 +29,19 @@ Assuming you have built the image by using the tag `ppiper/xs-cli`, you can run 
 docker run ppiper/xs-cli xs <command>
 ```
 
-## License
-Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE file](license).
+
+# License
+Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+
+Please note that Docker images can contain other software which may be licensed under different licenses. This License file is also included in the Docker image. For any usage of built Docker images please make sure to check the licenses of the artifacts contained in the images.
+
+[piper]: https://sap.github.io/jenkins-library/
+[xsclient]: https://developers.sap.com/germany/tutorials/hxe-ua-install-xs-xli-client.html
+[sapone]: https://launchpad.support.sap.com/
+[general]: https://github.com/SAP/devops-docker-images/blob/master/README.md
+[dockerbuild]: https://docs.docker.com/engine/reference/commandline/build/
+[dockerbuildadd]: https://docs.docker.com/engine/reference/builder/#add
+
 
 Please note that Docker images can contain other software which may be licensed under different licenses. This License file is also included in the Docker image. For any usage of built Docker images please make sure to check the licenses of the artifacts contained in the images.
 


### PR DESCRIPTION
Unfortunately we did some changes after splitting the xs-cli from https://github.com/SAP/devops-docker-images/ In this #PR I merge in these unfortunate changes.

* [Split request](https://github.wdf.sap.corp/OSPO/OSPO-request/issues/24)
* [original repo](https://github.com/SAP/devops-docker-images/tree/master/xs-cli)