### PR TITLE
Update Dockerfile to fix apt update error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch-curl
+FROM buildpack-deps:stable-curl
 
 ARG XSZIP
 ENV VERSION 0.1


### PR DESCRIPTION
apt update fails with this base image.

This fixes #11 